### PR TITLE
[SCAL-81062] [SCAL-80298] [SCAL-81068]

### DIFF
--- a/answer/index.js
+++ b/answer/index.js
@@ -3,6 +3,7 @@ import {
   init,
   PinboardEmbed,
   Action,
+  RuntimeFilterOp,
   EmbedEvent,
   AuthType
 } from "@thoughtspot/visual-embed-sdk";

--- a/answer/index.js
+++ b/answer/index.js
@@ -28,8 +28,8 @@ hideNoDataImage();
 
 embed
     // Register event listeners
-    .on("init", showLoader)
-    .on("load", hideLoader)
+    .on(EmbedEvent.Init, showLoader)
+    .on(EmbedEvent.Load, hideLoader)
     .on(EmbedEvent.Error, () => {
         showNoDataImage();
         hideLoader();

--- a/answer/templates.html
+++ b/answer/templates.html
@@ -17,6 +17,10 @@
 </script>
 <!-- runtimeFilters -->
 <script type="text/template" id="runtimeFilters">
-     runtimeFilters: [],
+     runtimeFilters: [{
+          columnName: 'color',
+          operator: RuntimeFilterOp.EQ,
+          values: [ 'red' ]
+          }],
 </script>
 

--- a/app/index.js
+++ b/app/index.js
@@ -19,6 +19,7 @@ init({
 const embed = new AppEmbed("#embed", {
     frameParams: {},
     /*param-start-showNavBar*//*param-end-showNavBar*/
+    /*param-start-navigateToUrl*//*param-end-navigateToUrl*/
     /*param-start-pageId*/pageId: "home",/*param-end-pageId*/
     /*param-start-modifyActions*//*param-end-modifyActions*/
     /*param-start-runtimeFilters*//*param-end-runtimeFilters*/
@@ -26,8 +27,8 @@ const embed = new AppEmbed("#embed", {
 
 embed
   // Register event listeners
-  .on("init", showLoader)
-  .on("load", hideLoader)
+  .on(EmbedEvent.Init, showLoader)
+  .on(EmbedEvent.Load, hideLoader)
   .render();
 
 // Functions to show and hide a loader while iframe loads

--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,7 @@ import {
   init,
   AppEmbed,
   Action,
+  RuntimeFilterOp,
   EmbedEvent,
   AuthType
 } from "@thoughtspot/visual-embed-sdk";

--- a/app/templates.html
+++ b/app/templates.html
@@ -15,8 +15,17 @@
 <script type="text/template" id="showNavBar">
      showPrimaryNavbar: true,
 </script>
+<!-- navigateToUrl-->
+<script type="text/template" id="navigateToUrl">
+     path: "pinboards",
+     // pinboard/pinboardId
+</script>
 <!-- runtimeFilters -->
 <script type="text/template" id="runtimeFilters">
-     runtimeFilters: [],
+     runtimeFilters: [{
+          columnName: 'color',
+          operator: RuntimeFilterOp.EQ,
+          values: [ 'red' ]
+          }],
 </script>
 

--- a/app/templates.html
+++ b/app/templates.html
@@ -17,8 +17,8 @@
 </script>
 <!-- navigateToUrl-->
 <script type="text/template" id="navigateToUrl">
-     path: "pinboards",
-     // pinboard/pinboardId
+     path: "",
+     // eg pinboard/[pinboardId] or insights/results
 </script>
 <!-- runtimeFilters -->
 <script type="text/template" id="runtimeFilters">

--- a/pinboard/index.js
+++ b/pinboard/index.js
@@ -27,8 +27,8 @@ hideNoDataImage();
 
 embed
     // Register event listeners
-    .on("init", showLoader)
-    .on("load", hideLoader)
+    .on(EmbedEvent.Init, showLoader)
+    .on(EmbedEvent.Load, hideLoader)
     .on(EmbedEvent.Error, () => {
         showNoDataImage();
         hideLoader();

--- a/pinboard/index.js
+++ b/pinboard/index.js
@@ -3,6 +3,7 @@ import {
   init,
   PinboardEmbed,
   Action,
+  RuntimeFilterOp,
   EmbedEvent,
   AuthType
 } from "@thoughtspot/visual-embed-sdk";

--- a/pinboard/templates.html
+++ b/pinboard/templates.html
@@ -13,6 +13,10 @@
 </script>
 <!-- runtimeFilters -->
 <script type="text/template" id="runtimeFilters">
-     runtimeFilters: [],
+     runtimeFilters: [{
+          columnName: 'color',
+          operator: RuntimeFilterOp.EQ,
+          values: [ 'red' ]
+          }],
 </script>
 

--- a/search/index.js
+++ b/search/index.js
@@ -31,8 +31,8 @@ const tsSearch = new SearchEmbed("#embed", {
 
 tsSearch
   // Register event handlers
-  .on("init", showLoader)
-  .on("load", hideLoader)
+  .on(EmbedEvent.Init, showLoader)
+  .on(EmbedEvent.Load, hideLoader)
   /*param-start-customActionHandle*//*param-end-customActionHandle*/
   .on("answerPageLoading", payload =>
     console.log("message received from embedded view" + JSON.stringify(payload))

--- a/search/templates.html
+++ b/search/templates.html
@@ -37,7 +37,11 @@
 </script>
 <!-- runtimeFilters -->
 <script type="text/template" id="runtimeFilters">
-    runtimeFilters: [],
+    runtimeFilters: [{
+        columnName: 'color',
+        operator: RuntimeFilterOp.EQ,
+        values: [ 'red' ]
+        }],
 </script>
 
 <!-- customActionHandle -->


### PR DESCRIPTION
SCAL-80298 - use enumerated types not string in playground example code
SCAL-81068 - knob for `path` in full app embed
SCAL-81062 - add runtime filters knob on full app target